### PR TITLE
WDI: problem with multiple countries and indicators

### DIFF
--- a/R/WDI.R
+++ b/R/WDI.R
@@ -33,6 +33,15 @@ WDI <- function(country = "all", indicator = "NY.GNS.ICTR.GN.ZS", start = 2002, 
         dat = dat[good] 
     }
     # MERGE
+     if(country!="all" &&length(country)>1){
+      dat2<-list()
+      indi<-unique(indicator)
+      for(i in 1:length(indi)) {
+	same_indic<-unlist(lapply(dat, function(x)  indi[i]%in%colnames(x)))
+	dat2[[i]] <- do.call(rbind, dat[same_indic])
+      }
+      dat<-dat2
+    }
     dat = Reduce(function(x,y) merge(x,y,all=TRUE), dat)
     # EXTRAS
     if(!is.null(cache)){


### PR DESCRIPTION
When multiple indicators are downloaded for many countries, one has a strucutre like:

[[1]] coun 1 var 1

[[2]] coun 1 var 2

[[3]] coun 2 var 1

[[4]] coun 2 var 2

this is not easily merged with dat = Reduce(function(x,y) merge(x,y,all=TRUE), dat)

Proposed solution is to first "rbind" same indicators over different countries, then apply usual 
dat = Reduce(function(x,y) merge(x,y,all=TRUE), dat)

but there is surely a most elegant/efficient solution!
