### PR TITLE
Implement Most Recent Values and Most Recent Non-Empty Values

### DIFF
--- a/R/WDI.R
+++ b/R/WDI.R
@@ -21,8 +21,7 @@ globalVariables(c('year', 'value', 'Country.Name', 'Country.Code', 'Indicator.Na
 #' @param extra TRUE returns extra variables such as region, iso3c code, and
 #'     incomeLevel.
 #' @param cache NULL (optional) a list created by WDIcache() to be used with the extra=TRUE argument.
-#' @param mrv Integer indicating the number of most recent values to get. Default is NULL.
-#' @param mrnev Integer indicating the number of most recent non-empty values to get. Default is NULL. 
+#' @param mrv,mrnev Integer indicating the number of most recent non-empty values to get. Specify only one of the two. Default is NULL. Incompatible with `start` and `end`. 
 #'     
 #' @details It is possible to only specify the `indicator` and the `country` arguments, in which case `WDI()` will return data from 1960 to the last year available on World Bank's website. 
 #' 
@@ -89,9 +88,13 @@ WDI <- function(country = "all",
       }
     }
     
-    # Sanity: needs dates or number of most recent values
+    # Sanity: needs dates or number of most recent values (but not both)
     if (is.null(start) && is.null(end) && is.null(mrv) && is.null(mrnev)) {
       stop("Need to specify dates or number of most recent values.")
+    }
+    if (!is.null(start) && !is.null(end) && 
+        (!is.null(mrnev) || !is.null(mrv))) {
+      stop("You can't specify dates and 'mrv' or 'mrnev' at the same time.")
     }
     
 

--- a/man/WDI.Rd
+++ b/man/WDI.Rd
@@ -11,8 +11,7 @@ WDI(
   end = 2020,
   extra = FALSE,
   cache = NULL,
-  mrv = NULL,
-  mrnev = NULL
+  latest = NULL
 )
 }
 \arguments{
@@ -35,7 +34,7 @@ incomeLevel.}
 
 \item{cache}{NULL (optional) a list created by WDIcache() to be used with the extra=TRUE argument.}
 
-\item{mrv, mrnev}{Integer indicating the number of most recent non-empty values to get. Specify only one of the two. Default is NULL. Overrides the specified dates.}
+\item{latest}{Integer indicating the number of most recent non-NA values to get. Default is NULL. If specified, it overrides the start and end dates.}
 }
 \value{
 Data frame with country-year observations. You can extract a
@@ -49,7 +48,7 @@ resulting XML file, and formats it in long country-year format.
 \details{
 It is possible to only specify the `indicator` and the `country` arguments, in which case `WDI()` will return data from 1960 to the last year available on World Bank's website. 
 
-It is also possible to get only the most recent values, whether empty or non-empty, with the arguments `mrv` (for Most Recent Values) and `mrnev` (for Most Recent Non-Empty Values). If one of those two arguments is specified, it is no longer required to provide `start` and `end` dates.
+It is also possible to get only the most recent non-NA values, with `latest`.
 }
 \examples{
 
@@ -63,6 +62,9 @@ WDI(country=c("US","BR"), indicator="NY.GNS.ICTR.GN.ZS", start=1999, end=2000,
 # Rename indicators on the fly
 WDI(country = 'CA', indicator = c('women_private_sector' = 'BI.PWK.PRVS.FE.ZS',
                                   'women_public_sector' = 'BI.PWK.PUBS.FE.ZS'))
+                                  
+# Get the 5 latest non-NA values
+WDI(country=c("US","BR"), indicator="NY.GNS.ICTR.GN.ZS", latest = 5)
 }
 
 }

--- a/man/WDI.Rd
+++ b/man/WDI.Rd
@@ -10,7 +10,9 @@ WDI(
   start = 1960,
   end = 2020,
   extra = FALSE,
-  cache = NULL
+  cache = NULL,
+  mrv = NULL,
+  mrnev = NULL
 )
 }
 \arguments{
@@ -29,10 +31,13 @@ greater.}
 the `start` argument.}
 
 \item{extra}{TRUE returns extra variables such as region, iso3c code, and
-incomeLevel}
+incomeLevel.}
 
-\item{cache}{NULL (optional) a list created by WDIcache() to be used with the
-extra=TRUE argument}
+\item{cache}{NULL (optional) a list created by WDIcache() to be used with the extra=TRUE argument.}
+
+\item{mrv}{Integer indicating the number of most recent values to get. Default is NULL.}
+
+\item{mrnev}{Integer indicating the number of most recent non-empty values to get. Default is NULL.}
 }
 \value{
 Data frame with country-year observations. You can extract a
@@ -42,6 +47,11 @@ data.frame with indicator names and descriptive labels by inspecting the
 \description{
 Downloads the requested data by using the World Bank's API, parses the
 resulting XML file, and formats it in long country-year format.
+}
+\details{
+It is possible to only specify the `indicator` and the `country` arguments, in which case `WDI()` will return data from 1960 to the last year available on World Bank's website. 
+
+It is also possible to get only the most recent values, whether empty or non-empty, with the arguments `mrv` (for Most Recent Values) and `mrnev` (for Most Recent Non-Empty Values). If one of those two arguments is specified, it is no longer required to provide `start` and `end` dates.
 }
 \examples{
 

--- a/man/WDI.Rd
+++ b/man/WDI.Rd
@@ -35,9 +35,7 @@ incomeLevel.}
 
 \item{cache}{NULL (optional) a list created by WDIcache() to be used with the extra=TRUE argument.}
 
-\item{mrv}{Integer indicating the number of most recent values to get. Default is NULL.}
-
-\item{mrnev}{Integer indicating the number of most recent non-empty values to get. Default is NULL.}
+\item{mrv, mrnev}{Integer indicating the number of most recent non-empty values to get. Specify only one of the two. Default is NULL. Overrides the specified dates.}
 }
 \value{
 Data frame with country-year observations. You can extract a

--- a/man/wdi.dl.Rd
+++ b/man/wdi.dl.Rd
@@ -4,7 +4,7 @@
 \alias{wdi.dl}
 \title{Internal function to download data}
 \usage{
-wdi.dl(indicator, country, start, end, mrv = NULL, mrnev = NULL)
+wdi.dl(indicator, country, start, end, latest = NULL)
 }
 \description{
 Internal function to download data

--- a/man/wdi.dl.Rd
+++ b/man/wdi.dl.Rd
@@ -4,7 +4,7 @@
 \alias{wdi.dl}
 \title{Internal function to download data}
 \usage{
-wdi.dl(indicator, country, start, end)
+wdi.dl(indicator, country, start, end, mrv = NULL, mrnev = NULL)
 }
 \description{
 Internal function to download data

--- a/man/wdi.query.Rd
+++ b/man/wdi.query.Rd
@@ -9,8 +9,7 @@ wdi.query(
   country = "all",
   start = 1960,
   end = 2020,
-  mrv = NULL,
-  mrnev = NULL
+  latest = NULL
 )
 }
 \description{

--- a/man/wdi.query.Rd
+++ b/man/wdi.query.Rd
@@ -8,7 +8,9 @@ wdi.query(
   indicator = "NY.GDP.PCAP.CD",
   country = "all",
   start = 1960,
-  end = 2020
+  end = 2020,
+  mrv = NULL,
+  mrnev = NULL
 )
 }
 \description{

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -79,44 +79,21 @@ test_that('WDI(extra = TRUE)', {
 
 })
 
-test_that("behavior of start/end dates with mrv/mrnev", {
-    expect_error(
-        WDI("all", "AG.AGR.TRAC.NO", start = NULL, end = NULL)
+test_that("behavior of start/end dates with latest", {
+   expect_silent(
+        WDI("all", "AG.AGR.TRAC.NO", start = NULL, end = NULL, latest = 5)
     )
     expect_silent(
-        WDI("all", "AG.AGR.TRAC.NO", start = NULL, end = NULL, mrv = 5)
-    )
-    expect_silent(
-        WDI("all", "AG.AGR.TRAC.NO", start = NULL, end = NULL, mrnev = 5)
-    )
-    expect_error(
-        WDI("all", "AG.AGR.TRAC.NO", start = 1980, end = 2000, mrv = 5)
-    )
-    expect_error(
-        WDI("all", "AG.AGR.TRAC.NO", start = 1980, end = 2000, mrnev = 5)
+        WDI("all", "AG.AGR.TRAC.NO", start = 1980, end = 2000, latest = 5)
     )
 })
 
-test_that("mrv and mrnev provides right dataframe", {
-    x <- WDI("all", "AG.AGR.TRAC.NO", start = NULL, end = NULL, mrv = 5)
-    expect_s3_class(x, "data.frame")
-    expect_equal(length(unique(x$year)), 5)
-    
-    y <- WDI("all", "AG.AGR.TRAC.NO", start = NULL, end = NULL, mrnev = 5)
+test_that("latest provides a dataframe", {
+   y <- WDI("all", "AG.AGR.TRAC.NO", start = NULL, end = NULL, latest = 5)
     expect_s3_class(y, "data.frame")
-    # Number of years can't be tested for mrnev as it can go back far 
-    # in time until every country has at least 5 obs
+    
+   z <- WDI("all", "AG.AGR.TRAC.NO", latest = 5)
+   expect_s3_class(z, "data.frame")
 })
 
-test_that("mrnev overrides mrv", {
-    # only mrnev
-    x <- WDI("all", "AG.AGR.TRAC.NO", start = NULL, end = NULL, mrnev = 5)
-    # both
-    y <- WDI("all", "AG.AGR.TRAC.NO", 
-             start = NULL, end = NULL, 
-             mrv = 5, mrnev = 5)
-    
-    expect_equal(unique(x$year), unique(y$year))
-    
-})
 

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -39,13 +39,13 @@ test_that('Bad year', {
 test_that('WDI', {
 
     # 1 country 1 indicator
-    x <- WDI(country='US', indicator='NY.GDP.PCAP.KD', start = 1990, end = 1991) 
+    x <- WDI(country='US', indicator='NY.GDP.PCAP.KD', start = 1990, end = 1991)
     expect_s3_class(x, 'data.frame')
     expect_equal(dim(x), c(2, 4))
 
     # 3 countries 1 indicator
-    x <- WDI(country=c('CA', 'MX', 'US'), 
-             indicator='NY.GDP.PCAP.KD', 
+    x <- WDI(country=c('CA', 'MX', 'US'),
+             indicator='NY.GDP.PCAP.KD',
              start=1990, end=1991)
     expect_s3_class(x, 'data.frame')
     expect_equal(dim(x), c(6, 4))
@@ -62,7 +62,7 @@ test_that('WDI', {
     x <- expect_warning(WDI(country = co, start=1990, end=1991))
     expect_equal(length(unique(x$iso2c)), 3)
 
-    # bad indicator 
+    # bad indicator
     ind <- c("blah blah", "NY.GDP.PCAP.KD", "NY.GDP.PCAP.KN", "NY.GDP.PCAP.PP.KD", "NY.GDP.PCAP.PP.KD.87")
     x <- expect_message(WDI(indicator = ind, start=1990, end=1991))
     expect_gte(nrow(x), 30)
@@ -72,9 +72,46 @@ test_that('WDI', {
 
 test_that('WDI(extra = TRUE)', {
 
-    x <- WDI(country='US', indicator='NY.GDP.PCAP.KD', 
+    x <- WDI(country='US', indicator='NY.GDP.PCAP.KD',
              start=1991, end=1992, extra = TRUE)
     expect_s3_class(x, 'data.frame')
     expect_equal(dim(x), c(2, 11))
 
 })
+
+test_that("start and end dates not required when specifying mrv or mrnev", {
+    expect_error(
+        WDI("all", "AG.AGR.TRAC.NO", start = NULL, end = NULL)
+    )
+    expect_silent(
+        WDI("all", "AG.AGR.TRAC.NO", start = NULL, end = NULL, mrv = 5)
+    )
+    expect_silent(
+        WDI("all", "AG.AGR.TRAC.NO", start = NULL, end = NULL, mrnev = 5)
+    )
+})
+
+test_that("mrv and mrnev provides right dataframe", {
+    x <- WDI("all", "AG.AGR.TRAC.NO", start = NULL, end = NULL, mrv = 5)
+    expect_s3_class(x, "data.frame")
+    expect_equal(length(unique(x$year)), 5)
+    
+    y <- WDI("all", "AG.AGR.TRAC.NO", start = NULL, end = NULL, mrnev = 5)
+    expect_s3_class(y, "data.frame")
+    # Number of years can't be tested for mrnev as it can go back far 
+    # in time until every country has at least 5 obs
+})
+
+test_that("mrnev overrides mrv", {
+    # only mrnev
+    x <- WDI("all", "AG.AGR.TRAC.NO", start = NULL, end = NULL, mrnev = 5)
+    # both
+    y <- WDI("all", "AG.AGR.TRAC.NO", 
+             start = NULL, end = NULL, 
+             mrv = 5, mrnev = 5)
+    
+    expect_equal(unique(x$year), unique(y$year))
+    
+})
+
+

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -79,7 +79,7 @@ test_that('WDI(extra = TRUE)', {
 
 })
 
-test_that("start and end dates not required when specifying mrv or mrnev", {
+test_that("behavior of start/end dates with mrv/mrnev", {
     expect_error(
         WDI("all", "AG.AGR.TRAC.NO", start = NULL, end = NULL)
     )
@@ -88,6 +88,12 @@ test_that("start and end dates not required when specifying mrv or mrnev", {
     )
     expect_silent(
         WDI("all", "AG.AGR.TRAC.NO", start = NULL, end = NULL, mrnev = 5)
+    )
+    expect_error(
+        WDI("all", "AG.AGR.TRAC.NO", start = 1980, end = 2000, mrv = 5)
+    )
+    expect_error(
+        WDI("all", "AG.AGR.TRAC.NO", start = 1980, end = 2000, mrnev = 5)
     )
 })
 
@@ -113,5 +119,4 @@ test_that("mrnev overrides mrv", {
     expect_equal(unique(x$year), unique(y$year))
     
 })
-
 


### PR DESCRIPTION
This PR adds two arguments to `WDI()` (without changing previous behavior):

* `mrv`, for Most Recent Values
* `mrnev`, for Most Recent Non-Empty Values

Here's an example. Suppose the WDI indicator is like:
```
> WDI(c("CHN", "FRA"), "SI.DST.FRST.20", start = 2010, end = 2020)

   iso2c country SI.DST.FRST.20 year
1     CN   China             NA 2020
2     CN   China             NA 2019
3     CN   China             NA 2018
4     CN   China             NA 2017
5     CN   China            6.5 2016
6     CN   China            6.4 2015
7     CN   China            6.2 2014
8     CN   China            6.2 2013
9     CN   China            5.3 2012
10    CN   China            5.4 2011
11    CN   China            5.1 2010
12    FR  France             NA 2020
13    FR  France             NA 2019
14    FR  France             NA 2018
15    FR  France            8.1 2017
16    FR  France            8.0 2016
17    FR  France            7.9 2015
18    FR  France            8.0 2014
19    FR  France            8.0 2013
20    FR  France            7.8 2012
21    FR  France            7.8 2011
22    FR  France            7.7 2010
```
Using `mrv = 5` will go back in time until it gets 5 observations from one country, i.e will produce:
```
 > WDI(c("CHN", "FRA"), "SI.DST.FRST.20", start = NULL, end = NULL, mrv = 5)

   iso2c country SI.DST.FRST.20 year
1     CN   China             NA 2017
2     CN   China            6.5 2016
3     CN   China            6.4 2015
4     CN   China            6.2 2014
5     CN   China            6.2 2013
6     FR  France            8.1 2017
7     FR  France            8.0 2016
8     FR  France            7.9 2015
9     FR  France            8.0 2014
10    FR  France            8.0 2013
```
Using `mrnev = 5` is a bit different. This will go back take the last 5 values for every country, and will produce:
```
> WDI(c("CHN", "FRA"), "SI.DST.FRST.20", start = NULL, end = NULL, mrnev = 5)

   iso2c country SI.DST.FRST.20 year
1     CN   China            6.5 2016
2     CN   China            6.4 2015
3     CN   China            6.2 2014
4     CN   China            6.2 2013
5     CN   China            5.3 2012
6     FR  France            8.1 2017
7     FR  France            8.0 2016
8     FR  France            7.9 2015
9     FR  France            8.0 2014
10    FR  France            8.0 2013
```
Note that:

* if `mrv` and `mrnev` are both supplied by the user, `mrnev` will override `mrv`;
* start/end dates and `mrv` or `mrnev` are incompatible (you can't specify dates and one of the two arguments at the same time)

Close #29