### PR TITLE
Add observation status in extra variables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ LazyData: yes
 Type: Package
 LazyLoad: yes
 Encoding: UTF-8
-Version: 2.7.4
+Version: 2.7.5.9000
 URL: https://vincentarelbundock.github.io/WDI/
 Depends:
     R (>= 3.5.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# WDI 2.7.5.9000
+
+* Add the observation status (whether an observation is a forecast) when `extra = TRUE` in `WDI()` (#48)
+
 # WDI 2.7.4
 
 * Bug fix for on-the-fly rename

--- a/man/WDI.Rd
+++ b/man/WDI.Rd
@@ -31,7 +31,7 @@ greater.}
 the `start` argument.}
 
 \item{extra}{TRUE returns extra variables such as region, iso3c code, and
-incomeLevel.}
+incomeLevel. See Details.}
 
 \item{cache}{NULL (optional) a list created by WDIcache() to be used with the extra=TRUE argument.}
 
@@ -49,9 +49,21 @@ Downloads the requested data by using the World Bank's API, parses the
 resulting XML file, and formats it in long country-year format.
 }
 \details{
-It is possible to only specify the `indicator` and the `country` arguments, in which case `WDI()` will return data from 1960 to the last year available on World Bank's website. 
+It is possible to only specify the `indicator` and the `country` arguments, in which case `WDI()` will return data from 1960 to the last year available on World Bank's website. It is also possible to get only the most recent non-NA values, with `latest`.
 
-It is also possible to get only the most recent non-NA values, with `latest`.
+If `extra = TRUE`, additional variables are provided:
+
+\itemize{
+
+\item{status: observation status, e.g is the observation a forecast?}
+\item{iso3c}
+\item{region}
+\item{capital: name of the capital city}
+\item{latitude, longitude}
+\item{income: income categories of the World Bank}
+\item{lending}
+
+}
 }
 \examples{
 

--- a/man/wdi.dl.Rd
+++ b/man/wdi.dl.Rd
@@ -4,7 +4,15 @@
 \alias{wdi.dl}
 \title{Internal function to download data}
 \usage{
-wdi.dl(indicator, country, start, end, latest = NULL, language = "en")
+wdi.dl(
+  indicator,
+  country,
+  start,
+  end,
+  latest = NULL,
+  language = "en",
+  extra = FALSE
+)
 }
 \description{
 Internal function to download data

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -75,8 +75,15 @@ test_that('WDI(extra = TRUE)', {
     x <- WDI(country='US', indicator='NY.GDP.PCAP.KD',
              start=1991, end=1992, extra = TRUE)
     expect_s3_class(x, 'data.frame')
-    expect_equal(dim(x), c(2, 11))
+    expect_equal(dim(x), c(2, 12))
 
+})
+
+test_that("extra = TRUE provides observation status", {
+    x <- WDI(country='US', indicator='NY.GDP.PCAP.KD',
+             start=1991, end=1992, extra = TRUE)
+    expect_true("status" %in% names(x))
+    expect_true(is.character(x$status))
 })
 
 test_that("behavior of start/end dates with latest", {


### PR DESCRIPTION
As discussed in #42, this PR adds the observation status (i.e whether the observation is a forecast) when `extra = TRUE` is specified in `WDI()`. I didn't find a list of possible values for this variable, but I only found "forecast" or empty so far. This is an example of the output:

```
> WDI("CHN", "NYGDPMKTPKDZ", start = 2015, extra = TRUE)
  iso2c country NYGDPMKTPKDZ year   status iso3c              region capital
1    CN   China          2.3 2020 forecast   CHN East Asia & Pacific Beijing
2    CN   China          6.0 2019            CHN East Asia & Pacific Beijing
3    CN   China          6.8 2018            CHN East Asia & Pacific Beijing
4    CN   China           NA 2017            CHN East Asia & Pacific Beijing
5    CN   China           NA 2016            CHN East Asia & Pacific Beijing
6    CN   China           NA 2015            CHN East Asia & Pacific Beijing
  longitude latitude              income lending
1   116.286  40.0495 Upper middle income    IBRD
2   116.286  40.0495 Upper middle income    IBRD
3   116.286  40.0495 Upper middle income    IBRD
4   116.286  40.0495 Upper middle income    IBRD
5   116.286  40.0495 Upper middle income    IBRD
6   116.286  40.0495 Upper middle income    IBRD
```

I also documented a bit more the variables provided by `extra = TRUE`.

**Question about defaults**

The observation status is particularly useful when we import a particular indicator without specifying the dates. On the World Bank API, when no dates are specified, the whole serie is returned. E.g for [this indicator](http://api.worldbank.org/v2/country/chn/indicator/NYGDPMKTPKDZ), the data goes until 2023, which is why knowing which observation is a forecast is helpful. However, the behavior of `WDI()` regarding dates is a bit strange:

* if I don't specify any start and end dates, the data will be downloaded from the year of creation of the indicator (1960 in most cases) to 2020
```
WDI("CHN", "NYGDPMKTPKDZ")
   iso2c country NYGDPMKTPKDZ year
1     CN   China          2.3 2020
2     CN   China          6.0 2019
...
21    CN   China           NA 2000
22    CN   China           NA 1999
```

* if I specify `end = NULL` then it gets until the most recent year

```
> WDI("CHN", "NYGDPMKTPKDZ", end = NULL)
   iso2c country NYGDPMKTPKDZ year
1     CN   China          5.3 2023
2     CN   China          5.4 2022
3     CN   China          8.5 2021
4     CN   China          2.3 2020
...
24    CN   China           NA 2000
25    CN   China           NA 1999
```

* if I specify `start = NULL` and `end = NULL`, then it errors

```
> WDI("CHN", "NYGDPMKTPKDZ", start = NULL, end = NULL)
Error in WDI("CHN", "NYGDPMKTPKDZ", start = NULL, end = NULL) : 
  Need to specify dates or number of latest values.
```

So I'm wondering if it would be better to change the default values for start and end, and to change the default behavior. To me, both start and end should be `NULL` if I don't specify anything, and if they are `NULL` then it should get all years, even after 2020. I don't know if this would be a breaking change in the code of other people. What do you think?