### PR TITLE
Download over 25000 Series in Cache

### DIFF
--- a/R/WDI.R
+++ b/R/WDI.R
@@ -410,7 +410,7 @@ wdi.dl = function(indicator, country, start, end, latest = NULL, language = "en"
 #' @export
 WDIcache = function(){
     # Series
-    series_url = 'https://api.worldbank.org/v2/indicator?per_page=25000&format=json'
+    series_url = 'https://api.worldbank.org/v2/indicator?per_page=50000&format=json'
     series_dat <- jsonlite::fromJSON(series_url)[[2]]
     series_dat <- data.frame(
         indicator = series_dat$id,


### PR DESCRIPTION
There are more than 25000 different series available. On March 28th 2026 the query returned 29495 observations.